### PR TITLE
Event details role based render routing

### DIFF
--- a/src/HOCs/RenderByContextAuth.js
+++ b/src/HOCs/RenderByContextAuth.js
@@ -7,7 +7,7 @@ const RenderByContextAuth = allowedRoles => ComponentToRender => props => {
     <AuthUserContext.Consumer>
       {userClaims => {
         if (userClaims != null) {
-          for (let i = 0; i < userClaims.length; i++) {
+          for (let i = 0; i < userClaims.length; i += 1) {
             if (allowedRoles.includes(userClaims[i])) {
               return <ComponentToRender {...props} />;
             }

--- a/src/HOCs/RoutingByContextAuth.js
+++ b/src/HOCs/RoutingByContextAuth.js
@@ -10,7 +10,7 @@ const RoutingByContextAuth = allowedRoles => WrappedComponent => props => {
     <AuthUserContext.Consumer>
       {userClaims => {
         if (userClaims != null) {
-          for (let i = 0; i < userClaims.length; i++) {
+          for (let i = 0; i < userClaims.length; i += 1) {
             if (allowedRoles.includes(userClaims[i])) {
               return (
                 <NavBar>

--- a/src/components/EventCard/index.js
+++ b/src/components/EventCard/index.js
@@ -16,8 +16,6 @@ import moment from 'moment';
 import { Link } from 'react-router-dom';
 import styles from './styles';
 
-// ${event.id}
-
 function EventCard({ event, classes }) {
   return (
     <>
@@ -37,7 +35,7 @@ function EventCard({ event, classes }) {
             <Button
               variant='outlined'
               color='primary'
-              to='/events/9AfJFBiIRrFec1fDBNoR'
+              to={`/events/${event.id}`}
               component={Link}
             >
               See More

--- a/src/components/EventDetails/index.js
+++ b/src/components/EventDetails/index.js
@@ -117,10 +117,12 @@ EventDetailsComponent.propTypes = {
     startDate: PropTypes.shape({
       nanoseconds: PropTypes.number.isRequired,
       seconds: PropTypes.number.isRequired,
+      toDate: PropTypes.func.isRequired,
     }),
     endDate: PropTypes.shape({
       nanoseconds: PropTypes.number.isRequired,
       seconds: PropTypes.number.isRequired,
+      toDate: PropTypes.func.isRequired,
     }),
     hosts: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
     location: PropTypes.string.isRequired,

--- a/src/components/EventDetails/styles.js
+++ b/src/components/EventDetails/styles.js
@@ -1,9 +1,8 @@
-const styles = theme => ({
+const styles = () => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    marginTop: theme.spacing(8),
   },
   container: {
     backgroundColor: 'white',


### PR DESCRIPTION
I made minor changes to EventDetails and EventCard.

For EventDetails, I just removed theme.spacing() since we don't need that anymore

For EventCard, when user clicks on "See More", it now goes to the EventDetailsPage with the id of the event they clicked on in Calendar.