### PR TITLE
Added import/order rules to auto rearrange our imports.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,42 @@
         ],
         "extensions": [".js", ".jsx", ".json"]
       }
-    }
+    },
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always-and-inside-groups",
+        "pathGroups": [
+          {
+            "pattern": "@Constants/*",
+            "group": "internal"
+          },
+          {
+            "pattern": "@SharedComponents/*",
+            "group": "internal"
+          },
+          {
+            "pattern": "@Services/*",
+            "group": "internal"
+          },
+          {
+            "pattern": "@Pages/*",
+            "group": "internal"
+          },
+          {
+            "pattern": "@HOCs/*",
+            "group": "internal"
+          },
+          {
+            "pattern": "@Images/*",
+            "group": "internal"
+          },
+          {
+            "pattern": "@Contexts/*",
+            "group": "internal"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -30,24 +30,7 @@
       {
         "ignore": ["firebase", "classes", "history", "children"]
       }
-    ]
-  },
-  "ignorePatterns": ["cypress"],
-  "settings": {
-    "import/resolver": {
-      "alias": {
-        "map": [
-          ["@Constants", "./src/constants"],
-          ["@SharedComponents", "./src/components"],
-          ["@Services", "./src/services"],
-          ["@Pages", "./src/pages"],
-          ["@HOCs", "./src/HOCs"],
-          ["@Images", "./src/images"],
-          ["@Contexts", "./src/contexts"]
-        ],
-        "extensions": [".js", ".jsx", ".json"]
-      }
-    },
+    ],
     "import/order": [
       "error",
       {
@@ -84,5 +67,22 @@
         ]
       }
     ]
+  },
+  "ignorePatterns": ["cypress"],
+  "settings": {
+    "import/resolver": {
+      "alias": {
+        "map": [
+          ["@Constants", "./src/constants"],
+          ["@SharedComponents", "./src/components"],
+          ["@Services", "./src/services"],
+          ["@Pages", "./src/pages"],
+          ["@HOCs", "./src/HOCs"],
+          ["@Images", "./src/images"],
+          ["@Contexts", "./src/contexts"]
+        ],
+        "extensions": [".js", ".jsx", ".json"]
+      }
+    }
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,7 @@
     "import/order": [
       "error",
       {
-        "newlines-between": "always-and-inside-groups",
+        "newlines-between": "always",
         "pathGroups": [
           {
             "pattern": "@Constants/*",

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-const { useBabelRc, override, addWebpackAlias } = require('customize-cra');
 const path = require('path');
+
+const { useBabelRc, override, addWebpackAlias } = require('customize-cra');
 
 module.exports = override(
   useBabelRc(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6276,7 +6276,6 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/customize-cra/-/customize-cra-0.9.1.tgz",
       "integrity": "sha512-LISruJ6ak6u+HVQ2vPI+HE4inpPugB73KB9YIpE2J1TW5L1Vrjzm3l2Yupyy+1alJGwAd5GAb5Hfc9qmSUuHow==",
-      "dev": true,
       "requires": {
         "lodash.flow": "^3.5.0"
       }
@@ -13291,8 +13290,7 @@
     "lodash.flow": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
-      "dev": true
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
     },
     "lodash.has": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@material-ui/pickers": "^3.2.10",
     "@material/layout-grid": "^0.41.0",
     "classnames": "^2.2.6",
+    "customize-cra": "^0.9.1",
     "date-fns": "^2.14.0",
     "dotenv": "^6.2.0",
     "firebase": "^6.4.0",
@@ -52,7 +53,6 @@
   ],
   "devDependencies": {
     "@material-ui/codemod": "^4.5.0",
-    "customize-cra": "^0.9.1",
     "cypress": "^4.11.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.2.0",

--- a/src/components/FormLayout/index.js
+++ b/src/components/FormLayout/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-
 import { Grid, Typography, Divider } from '@material-ui/core';
 
 import Button from '../buttons';

--- a/src/components/FormLayout/index.js
+++ b/src/components/FormLayout/index.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { Grid, Typography, Divider } from '@material-ui/core';
 
 import Button from '../buttons';
+
 import styles from './styles';
 
 function TitleSectionComponent({ title, readOnly, editEndpoint, classes }) {

--- a/src/components/InputField/index.js
+++ b/src/components/InputField/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { TextField } from '@material-ui/core';
 import { TextField as FormikTextField } from 'formik-material-ui';
 import { Field } from 'formik';

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-
 import { compose } from 'recompose';
-
 import { withStyles } from '@material-ui/core/styles';
 import {
   CssBaseline,
@@ -25,12 +23,10 @@ import {
   DialogTitle,
   Hidden,
 } from '@material-ui/core';
-
 import SignOutIcon from '@material-ui/icons/ExitToApp';
 import MenuIcon from '@material-ui/icons/Menu';
 
 import { OfficerTabs, InducteeTabs } from './tabs';
-
 import styles from './styles';
 
 import { AuthUserContext } from '@Contexts';

--- a/src/components/NavBar/index.js
+++ b/src/components/NavBar/index.js
@@ -29,11 +29,13 @@ import {
 import SignOutIcon from '@material-ui/icons/ExitToApp';
 import MenuIcon from '@material-ui/icons/Menu';
 
+import { OfficerTabs, InducteeTabs } from './tabs';
+
+import styles from './styles';
+
 import { AuthUserContext } from '@Contexts';
 import { isOfficer as checkIsOfficer } from '@Services/claims';
 import { doSignOut } from '@Services/auth';
-import { OfficerTabs, InducteeTabs } from './tabs';
-import styles from './styles';
 
 const INITIAL_STATES = {
   isDrawerOpen: false,

--- a/src/components/NavBar/tabs.js
+++ b/src/components/NavBar/tabs.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import AssessmentOutlinedIcon from '@material-ui/icons/AssessmentOutlined';
 import AttachmentIcon from '@material-ui/icons/Attachment';
 import ListAltIcon from '@material-ui/icons/ListAlt';

--- a/src/components/NavBar/tabs.js
+++ b/src/components/NavBar/tabs.js
@@ -5,6 +5,7 @@ import AttachmentIcon from '@material-ui/icons/Attachment';
 import ListAltIcon from '@material-ui/icons/ListAlt';
 import EventIcon from '@material-ui/icons/Event';
 import HomeIcon from '@material-ui/icons/Home';
+
 import * as ROUTES from '@Constants/routes';
 
 const CalendarTab = {

--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -1,5 +1,4 @@
 import React, { forwardRef } from 'react';
-
 import AddBox from '@material-ui/icons/AddBox';
 import ArrowUpward from '@material-ui/icons/ArrowUpward';
 import Check from '@material-ui/icons/Check';
@@ -15,7 +14,6 @@ import Remove from '@material-ui/icons/Remove';
 import SaveAlt from '@material-ui/icons/SaveAlt';
 import Search from '@material-ui/icons/Search';
 import ViewColumn from '@material-ui/icons/ViewColumn';
-
 import MaterialTable from 'material-table';
 
 const tableIcons = {

--- a/src/components/Tags/index.js
+++ b/src/components/Tags/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { Chip } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 

--- a/src/components/buttons/index.js
+++ b/src/components/buttons/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { Button as MuiButton } from '@material-ui/core';
 
 export default function Button({

--- a/src/components/dropdowns/MajorDropdownField/index.js
+++ b/src/components/dropdowns/MajorDropdownField/index.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-
 import { MenuItem } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { Field } from 'formik';

--- a/src/components/dropdowns/MajorDropdownField/index.js
+++ b/src/components/dropdowns/MajorDropdownField/index.js
@@ -6,8 +6,9 @@ import { withStyles } from '@material-ui/core/styles';
 import { Field } from 'formik';
 import { TextField } from 'formik-material-ui';
 
-import ELIGIBLE_MAJORS from '@Constants/eligibleMajors';
 import styles from './styles';
+
+import ELIGIBLE_MAJORS from '@Constants/eligibleMajors';
 
 const createFullMajorTitle = (department, major) => {
   let fullMajorTitle = '';

--- a/src/components/dropdowns/YearDropdownField/index.js
+++ b/src/components/dropdowns/YearDropdownField/index.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-
 import { MenuItem } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { Field } from 'formik';

--- a/src/components/formSections/PersonalInfoSection.js
+++ b/src/components/formSections/PersonalInfoSection.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { Grid } from '@material-ui/core';
 
 import InputField from '../InputField';

--- a/src/components/modals/base/BaseModal.js
+++ b/src/components/modals/base/BaseModal.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import {
   Dialog,
   DialogActions,

--- a/src/components/modals/base/ButtonWithModal.js
+++ b/src/components/modals/base/ButtonWithModal.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Button from '../../buttons';
+
 import BaseModal from './BaseModal';
 
 const ButtonWithModal = props => {

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Button from '../buttons';
+
 import ButtonWithModal from './base/ButtonWithModal';
 
 export const ButtonWithConfirmationModal = ({

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,9 @@ import ReactDOM from 'react-dom';
 import * as firebase from 'firebase/app';
 import 'firebase/firestore';
 
-import App from '@Pages/App';
-
 import * as serviceWorker from './serviceWorker';
+
+import App from '@Pages/App';
 
 const config = {
   apiKey: process.env.REACT_APP_API_KEY,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
 import * as firebase from 'firebase/app';
 import 'firebase/firestore';
 

--- a/src/pages/App/index.js
+++ b/src/pages/App/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import * as firebase from 'firebase/app';
 import 'firebase/auth';
-
-import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 
 import {
   SignInPage,
@@ -19,7 +18,6 @@ import { Loading } from '@SharedComponents';
 import { AuthUserContext } from '@Contexts';
 import * as ROUTES from '@Constants/routes';
 import { ClaimsSingleton } from '@Services/claims';
-
 import {
   InducteeRoutingPermission,
   OfficerRoutingPermission,

--- a/src/pages/App/index.js
+++ b/src/pages/App/index.js
@@ -3,6 +3,7 @@ import * as firebase from 'firebase/app';
 import 'firebase/auth';
 
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
+
 import {
   SignInPage,
   SignUpPage,

--- a/src/pages/CalendarPage/components/Calendar/index.js
+++ b/src/pages/CalendarPage/components/Calendar/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import {
   Scheduler,
   DayView,
@@ -12,7 +11,6 @@ import {
   TodayButton,
   DateNavigator,
 } from '@devexpress/dx-react-scheduler-material-ui';
-
 import { ViewState } from '@devexpress/dx-react-scheduler';
 
 const AppointmentWithClick = handleClick => props => (

--- a/src/pages/CalendarPage/components/EventCard/index.js
+++ b/src/pages/CalendarPage/components/EventCard/index.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import { Link } from 'react-router-dom';
+
 import styles from './styles';
 
 function EventCard({ event, classes }) {

--- a/src/pages/CalendarPage/components/EventCard/index.js
+++ b/src/pages/CalendarPage/components/EventCard/index.js
@@ -9,10 +9,8 @@ import {
 } from '@material-ui/core';
 import RoomIcon from '@material-ui/icons/Room';
 import { withStyles } from '@material-ui/core/styles';
-
 import PropTypes from 'prop-types';
 import moment from 'moment';
-
 import { Link } from 'react-router-dom';
 
 import styles from './styles';

--- a/src/pages/CalendarPage/components/EventList/index.js
+++ b/src/pages/CalendarPage/components/EventList/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 import moment from 'moment';
 

--- a/src/pages/CalendarPage/components/EventList/index.js
+++ b/src/pages/CalendarPage/components/EventList/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 import moment from 'moment';
+
 import { Table } from '@SharedComponents';
 
 const eventDateComparator = (dateTimeA, dateTimeB) => {

--- a/src/pages/CalendarPage/index.js
+++ b/src/pages/CalendarPage/index.js
@@ -1,12 +1,10 @@
 import React from 'react';
-
 import { withStyles } from '@material-ui/core/styles';
 import { Grid, Paper, Container, Button } from '@material-ui/core';
 
 import Calendar from './components/Calendar';
 import EventCard from './components/EventCard';
 import EventList from './components/EventList';
-
 import styles from './styles';
 
 import { getAllEvents } from '@Services/events';

--- a/src/pages/CalendarPage/index.js
+++ b/src/pages/CalendarPage/index.js
@@ -3,12 +3,13 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Grid, Paper, Container, Button } from '@material-ui/core';
 
-import { getAllEvents } from '@Services/events';
 import Calendar from './components/Calendar';
 import EventCard from './components/EventCard';
 import EventList from './components/EventList';
 
 import styles from './styles';
+
+import { getAllEvents } from '@Services/events';
 
 class CalendarPage extends React.Component {
   constructor(props) {

--- a/src/pages/EventDetailsPage/components/DeleteEditButtons/index.js
+++ b/src/pages/EventDetailsPage/components/DeleteEditButtons/index.js
@@ -6,10 +6,11 @@ import { withStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';
 
+import styles from './styles';
+
 import { Button, ButtonWithConfirmationModal } from '@SharedComponents';
 import * as ROUTES from '@Constants/routes';
 import { deleteEventById } from '@Services/events';
-import styles from './styles';
 
 const DeleteEditButtons = props => {
   const { classes, eventId } = props;

--- a/src/pages/EventDetailsPage/components/DeleteEditButtons/index.js
+++ b/src/pages/EventDetailsPage/components/DeleteEditButtons/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-
 import { withStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import EditIcon from '@material-ui/icons/Edit';

--- a/src/pages/EventDetailsPage/components/EventDetails/Links.js
+++ b/src/pages/EventDetailsPage/components/EventDetails/Links.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { withStyles } from '@material-ui/core/styles';
 import { grey } from '@material-ui/core/colors';
 import {

--- a/src/pages/EventDetailsPage/components/EventDetails/index.js
+++ b/src/pages/EventDetailsPage/components/EventDetails/index.js
@@ -2,19 +2,16 @@ import React from 'react';
 import { Typography, Container, Card, Button, Grid } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { Link } from 'react-router-dom';
-
 import moment from 'moment';
 import PropTypes from 'prop-types';
 
 import DeleteEditButtons from '../DeleteEditButtons';
 
 import Links from './Links';
-
 import styles from './styles';
 
 import { Tags } from '@SharedComponents';
 import { OfficerRenderPermission } from '@HOCs/RenderByContextPerm';
-
 import * as ROUTES from '@Constants/routes';
 
 function EventDetailsComponent(props) {

--- a/src/pages/EventDetailsPage/components/EventDetails/index.js
+++ b/src/pages/EventDetailsPage/components/EventDetails/index.js
@@ -6,13 +6,16 @@ import { Link } from 'react-router-dom';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 
+import DeleteEditButtons from '../DeleteEditButtons';
+
+import Links from './Links';
+
+import styles from './styles';
+
 import { Tags } from '@SharedComponents';
 import { OfficerRenderPermission } from '@HOCs/RenderByContextPerm';
 
 import * as ROUTES from '@Constants/routes';
-import DeleteEditButtons from '../DeleteEditButtons';
-import Links from './Links';
-import styles from './styles';
 
 function EventDetailsComponent(props) {
   const { classes, eventInfo, eventId } = props;

--- a/src/pages/EventDetailsPage/index.js
+++ b/src/pages/EventDetailsPage/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import EventDetailsComponent from './components/EventDetails';
+
 import { Loading } from '@SharedComponents';
 import { getEventById } from '@Services/events';
-import EventDetailsComponent from './components/EventDetails';
 
 class EventDetailsPage extends React.Component {
   constructor(props) {

--- a/src/pages/EventEditPage/components/ChipListInput/index.js
+++ b/src/pages/EventEditPage/components/ChipListInput/index.js
@@ -10,6 +10,7 @@ import {
   InputAdornment,
 } from '@material-ui/core';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
+
 import styles from './styles';
 
 class ChipListInput extends React.Component {

--- a/src/pages/EventEditPage/components/EventEditForm/edit_form.js
+++ b/src/pages/EventEditPage/components/EventEditForm/edit_form.js
@@ -10,10 +10,11 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import MomentUtils from '@date-io/moment';
 import * as Yup from 'yup';
 
-import EVENT_TAGS from '@Constants/eventTags';
 import FormikChipListInput from './form_chip_list_input';
 import FormikMultiChipSelect from './form_multi_chip_select';
 import styles from './styles';
+
+import EVENT_TAGS from '@Constants/eventTags';
 
 const schema = Yup.object({
   name: Yup.string().required('Required'),

--- a/src/pages/EventEditPage/components/EventEditForm/edit_form.js
+++ b/src/pages/EventEditPage/components/EventEditForm/edit_form.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-material-ui';
-
 import { withStyles } from '@material-ui/core/styles';
 import { Button, LinearProgress, Grid } from '@material-ui/core';
 import { DateTimePicker } from 'formik-material-ui-pickers';

--- a/src/pages/EventEditPage/components/MultiChipSelect/index.js
+++ b/src/pages/EventEditPage/components/MultiChipSelect/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { Chip, Select, MenuItem, Input, InputLabel } from '@material-ui/core';
 
 class MultiChipSelect extends React.Component {

--- a/src/pages/EventEditPage/event_edit.js
+++ b/src/pages/EventEditPage/event_edit.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-import { getEventById, setEventDetails } from '@Services/events';
 import EventEditForm from './components/EventEditForm';
+
+import { getEventById, setEventDetails } from '@Services/events';
 
 class EventEditPage extends React.Component {
   constructor(props) {

--- a/src/pages/EventsPage/index.js
+++ b/src/pages/EventsPage/index.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { compose } from 'recompose';
 import { Divider } from '@material-ui/core';
-import { queryCurrentUserRole } from '@Services/user';
+
 import EventButtons from './eventButtons';
+
+import { queryCurrentUserRole } from '@Services/user';
 
 const styles = theme => ({
   root: {

--- a/src/pages/InducteePointsPage/PointDetail.js
+++ b/src/pages/InducteePointsPage/PointDetail.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import { compose } from 'recompose';
 import PropTypes from 'prop-types';
-
 import {
   Grid,
   Card,

--- a/src/pages/InducteePointsPage/index.js
+++ b/src/pages/InducteePointsPage/index.js
@@ -3,6 +3,9 @@ import React from 'react';
 import { compose } from 'recompose';
 import { withStyles } from '@material-ui/core/styles';
 import { Redirect } from 'react-router-dom';
+
+import PointDetail from './PointDetail';
+
 import { Table } from '@SharedComponents';
 
 import { USER_ROLES } from '@Constants/roles';
@@ -10,7 +13,6 @@ import * as ROUTES from '@Constants/routes';
 
 import { queryCurrentUserRole } from '@Services/user';
 import { getInducteesInfo } from '@Services/officer';
-import PointDetail from './PointDetail';
 
 const INITIAL_STATE = {
   users: [],

--- a/src/pages/InducteePointsPage/index.js
+++ b/src/pages/InducteePointsPage/index.js
@@ -7,10 +7,8 @@ import { Redirect } from 'react-router-dom';
 import PointDetail from './PointDetail';
 
 import { Table } from '@SharedComponents';
-
 import { USER_ROLES } from '@Constants/roles';
 import * as ROUTES from '@Constants/routes';
-
 import { queryCurrentUserRole } from '@Services/user';
 import { getInducteesInfo } from '@Services/officer';
 

--- a/src/pages/PointsPage/points.js
+++ b/src/pages/PointsPage/points.js
@@ -3,13 +3,14 @@ import { withStyles } from '@material-ui/core/styles';
 import { compose } from 'recompose';
 import { Grid, Divider } from '@material-ui/core';
 
+import PointDisplay from './point_display';
+
 import { USER_ROLES } from '@Constants/roles';
 import { POINT_TYPE } from '@Constants/pointtype';
 
 import { getCurrentUserDocument } from '@Services/user';
 import getEnumMap from '@Services/general';
 import { getPoints } from '@Services/events';
-import PointDisplay from './point_display';
 
 const styles = theme => ({
   root: {

--- a/src/pages/PointsPage/points.js
+++ b/src/pages/PointsPage/points.js
@@ -7,7 +7,6 @@ import PointDisplay from './point_display';
 
 import { USER_ROLES } from '@Constants/roles';
 import { POINT_TYPE } from '@Constants/pointtype';
-
 import { getCurrentUserDocument } from '@Services/user';
 import getEnumMap from '@Services/general';
 import { getPoints } from '@Services/events';

--- a/src/pages/ProfileEditPage/index.js
+++ b/src/pages/ProfileEditPage/index.js
@@ -5,7 +5,6 @@ import { Card, CardContent, Grid } from '@material-ui/core';
 import { Formik, Form } from 'formik';
 
 import schema from './schema';
-
 import styles from './styles';
 
 import { FormLayout } from '@SharedComponents';

--- a/src/pages/ProfileEditPage/index.js
+++ b/src/pages/ProfileEditPage/index.js
@@ -4,14 +4,16 @@ import { withStyles } from '@material-ui/core/styles';
 import { Card, CardContent, Grid } from '@material-ui/core';
 import { Formik, Form } from 'formik';
 
+import schema from './schema';
+
+import styles from './styles';
+
 import { FormLayout } from '@SharedComponents';
 import {
   getAccountSection,
   getPersonalInfoSection,
 } from '@SharedComponents/formSections';
 import { PROFILE_WITH_ID } from '@Constants/routes';
-import schema from './schema';
-import styles from './styles';
 
 class ProfileEditPage extends React.Component {
   constructor(props) {

--- a/src/pages/ProfilePage/index.js
+++ b/src/pages/ProfilePage/index.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { withStyles } from '@material-ui/core/styles';
-
 import { Card, CardContent, Grid } from '@material-ui/core';
 
 import styles from './styles';

--- a/src/pages/ProfilePage/index.js
+++ b/src/pages/ProfilePage/index.js
@@ -5,13 +5,14 @@ import { withStyles } from '@material-ui/core/styles';
 
 import { Card, CardContent, Grid } from '@material-ui/core';
 
+import styles from './styles';
+
 import { FormLayout } from '@SharedComponents';
 import {
   getAccountSection,
   getPersonalInfoSection,
 } from '@SharedComponents/formSections';
 import { PROFILE_EDIT_WITH_ID } from '@Constants/routes';
-import styles from './styles';
 
 class ProfilePage extends React.Component {
   constructor(props) {

--- a/src/pages/ResumePage/index.js
+++ b/src/pages/ResumePage/index.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
-
 import DeleteIcon from '@material-ui/icons/Delete';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import CloudDownloadIcon from '@material-ui/icons/CloudDownload';
 import PdfIcon from '@material-ui/icons/PictureAsPdf';
-
 import { compose } from 'recompose';
 import {
   Typography,

--- a/src/pages/SignInPage/index.js
+++ b/src/pages/SignInPage/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import * as firebase from 'firebase/app';
 import 'firebase/auth';
 import withStyles from '@material-ui/core/styles/withStyles';
-
 import { Link, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import {
@@ -26,7 +25,6 @@ import {
 
 import * as ROUTES from '@Constants/routes';
 import * as LOGO_URL from '@Images/hkn-trident.png';
-
 import {
   doSignInWithEmailAndPassword,
   doSignOut,

--- a/src/pages/SignInPage/index.js
+++ b/src/pages/SignInPage/index.js
@@ -23,6 +23,7 @@ import {
   Checkbox,
   FormControlLabel,
 } from '@material-ui/core';
+
 import * as ROUTES from '@Constants/routes';
 import * as LOGO_URL from '@Images/hkn-trident.png';
 

--- a/src/pages/SignUpPage/components/SignUpForm/index.js
+++ b/src/pages/SignUpPage/components/SignUpForm/index.js
@@ -8,10 +8,12 @@ import { TextField } from 'formik-material-ui';
 
 import { Formik, Field, Form } from 'formik';
 
+import styles from './styles';
+
+import schema from './schema';
+
 import * as ROUTES from '@Constants/routes';
 import { MajorDropdownField, YearDropdownField } from '@SharedComponents';
-import styles from './styles';
-import schema from './schema';
 
 const INITIAL_INPUT_BOX_VALUES = {
   email: '',

--- a/src/pages/SignUpPage/components/SignUpForm/index.js
+++ b/src/pages/SignUpPage/components/SignUpForm/index.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-
 import { Button, Grid, LinearProgress } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { TextField } from 'formik-material-ui';
-
 import { Formik, Field, Form } from 'formik';
 
 import styles from './styles';
-
 import schema from './schema';
 
 import * as ROUTES from '@Constants/routes';

--- a/src/pages/SignUpPage/index.js
+++ b/src/pages/SignUpPage/index.js
@@ -3,10 +3,12 @@ import React from 'react';
 import { Avatar, Card } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 
+import SignUpForm from './components/SignUpForm';
+
+import styles from './styles';
+
 import { createUserAccountFromSignup } from '@Services/auth';
 import HKN_TRIDENT_LOGO from '@Images/hkn-trident.png';
-import SignUpForm from './components/SignUpForm';
-import styles from './styles';
 
 const INITIAL_STATE = {};
 

--- a/src/pages/SignUpPage/index.js
+++ b/src/pages/SignUpPage/index.js
@@ -1,10 +1,8 @@
 import React from 'react';
-
 import { Avatar, Card } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 
 import SignUpForm from './components/SignUpForm';
-
 import styles from './styles';
 
 import { createUserAccountFromSignup } from '@Services/auth';


### PR DESCRIPTION
I ran 'npm run lint' but didn't really see things change. Idk if
that's just because the files I checked were already in the correct
import style, or it just didn't work... Also, had to put it in
"settings" instead of having it be a top-level "import/order" rule,
even though "eslint-plugin-import" docs on "import/order" seems
to indicate that it could be top-level.