### PR TITLE
Limit checkoff to attendees only.

### DIFF
--- a/src/pages/EventDetailsPage/index.tsx
+++ b/src/pages/EventDetailsPage/index.tsx
@@ -42,7 +42,7 @@ function EventDetailsPage(): JSX.Element {
 
       <Grid item xs={12}>
         <CheckOffTable
-          getAttendances={() => getEventAttendances(eventId, true, false)}
+          getAttendances={() => getEventAttendances(eventId, true, true)}
           checkOffAttendance={checkOffAttendance}
           eventId={eventId}
         />


### PR DESCRIPTION
There's confusion on who we're really checking off - we should just display inductees to be checked off for now.