### PR TITLE
Add token refresh to solve empty token.

### DIFF
--- a/src/pages/SignInPage/index.js
+++ b/src/pages/SignInPage/index.js
@@ -127,8 +127,8 @@ class SignInPage extends React.Component {
         return getCurrentUserIDAndToken();
       })
       .then(authObj => {
-        const { userID, token } = authObj;
-        return setClaims(userID, token);
+        const { userID } = authObj;
+        return setClaims(userID);
       })
       .then(() => {
         if (firebase.auth().currentUser.emailVerified) {

--- a/src/services/ApiConfigStore.ts
+++ b/src/services/ApiConfigStore.ts
@@ -12,16 +12,33 @@ class ApiConfigStoreClass {
 
   private config: Configuration = new Configuration(this.configParams);
 
-  getApiConfig(): Configuration {
-    return this.config;
+  private getTokenFunc: () => Promise<string>;
+
+  constructor(getTokenFunc: () => Promise<string>) {
+    this.getTokenFunc = getTokenFunc;
   }
 
-  // this is gonna be called on login
-  setToken(token: string) {
-    this.configParams.accessToken = token;
+  async getApiConfig(): Promise<Configuration> {
+    const newToken = await this.getTokenFunc();
+    if (newToken === this.configParams.accessToken) {
+      return Promise.resolve(this.config);
+    }
+
+    this.configParams.accessToken = newToken;
     this.config = new Configuration(this.configParams);
+
+    return Promise.resolve(this.config);
+  }
+
+  setGetTokenFunc(getTokenFunc: () => Promise<string>) {
+    this.getTokenFunc = getTokenFunc;
   }
 }
 
-const ApiConfigStore = new ApiConfigStoreClass();
+export const emptyGetTokenFunc: () => Promise<string> = () => {
+  return Promise.resolve('');
+};
+
+// default to empty token
+const ApiConfigStore = new ApiConfigStoreClass(emptyGetTokenFunc);
 export default ApiConfigStore;

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -6,7 +6,7 @@ import { Configuration } from './api/runtime';
 export async function createNewUser(
   appUserSignupRequest: AppUserSignupRequest
 ): Promise<AppUserResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const authApi: AuthApi = new AuthApi(apiConfig);
   const request: AuthControllerSignUpUserRequest = { appUserSignupRequest };
 

--- a/src/services/EventService.ts
+++ b/src/services/EventService.ts
@@ -27,7 +27,7 @@ export {
 } from './api/models';
 
 export async function getAllEvents(): Promise<MultipleEventResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   return eventApi.eventControllerGetMultipleEvents();
 }
@@ -37,7 +37,7 @@ export async function getEventAttendances(
   unchecked?: boolean,
   inductee?: boolean
 ): Promise<MultipleAttendanceResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerGetEventAttendanceRequest = {
     eventID,
@@ -52,7 +52,7 @@ export async function checkOffAttendance(
   eventID: number,
   attendeeID: number
 ): Promise<AttendanceResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerCheckOffEventAttendanceRequest = {
     eventID,
@@ -63,7 +63,7 @@ export async function checkOffAttendance(
 }
 
 export async function getEventById(eventID: number): Promise<EventResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerGetEventRequest = {
     eventID,
@@ -74,7 +74,7 @@ export async function getEventById(eventID: number): Promise<EventResponse> {
 export async function createEvent(
   eventRequest: EventRequest
 ): Promise<EventResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerCreateEventRequest = {
     eventRequest,
@@ -84,7 +84,7 @@ export async function createEvent(
 }
 
 export async function updateEvent(eventID: number, eventRequest: EventRequest) {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerUpdateEventRequest = {
     eventID,
@@ -95,7 +95,7 @@ export async function updateEvent(eventID: number, eventRequest: EventRequest) {
 }
 
 export async function deleteEvent(eventID: number): Promise<EventResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerDeleteEventRequest = {
     eventID,
@@ -108,7 +108,7 @@ export async function signInToEvent(
   eventID: number,
   appUserEventRequest: AppUserEventRequest
 ): Promise<AttendanceResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerSignInToEventRequest = {
     eventID,
@@ -122,7 +122,7 @@ export async function rsvpToEvent(
   eventID: number,
   appUserEventRequest: AppUserEventRequest
 ): Promise<RSVPResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const eventApi: EventApi = new EventApi(apiConfig);
   const request: EventControllerRsvpForEventRequest = {
     eventID,

--- a/src/services/InductionClassService.ts
+++ b/src/services/InductionClassService.ts
@@ -14,7 +14,7 @@ export {
 export async function getInterviewStartDates(
   inductionClassID: string
 ): Promise<InterviewDatesResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const inductionClassApi: InductionClassApi = new InductionClassApi(apiConfig);
   const req: InductionClassControllerGetInterviewDatesRequest = {
     inductionClassID,

--- a/src/services/PointsService.ts
+++ b/src/services/PointsService.ts
@@ -13,7 +13,7 @@ export interface InducteePoint {
 
 // nit: might be better to move the bool => string conversion out into page/component later
 export async function getAllInducteePoints(): Promise<InducteePoint[]> {
-  const apiConfig = ApiConfigStore.getApiConfig();
+  const apiConfig = await ApiConfigStore.getApiConfig();
   const pointsApi: PointsApi = new PointsApi(apiConfig);
 
   const points = await pointsApi.pointsControllerGetAllInducteePoints();

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -30,7 +30,7 @@ export interface InterviewAvailability {
 export async function getUserProfile(
   userID: number
 ): Promise<AppUserProfileResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const userApi = new UserApi(apiConfig);
   const request: UserControllerGetUserProfileRequest = {
     userID,
@@ -42,7 +42,7 @@ export async function getUserProfile(
 export async function getMultipleUsers(
   queryParams: UserControllerGetMultipleUsersRequest
 ): Promise<MultipleAppUserResponse | MultipleUserNameResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const userApi = new UserApi(apiConfig);
 
   return userApi.userControllerGetMultipleUsers(queryParams);
@@ -73,7 +73,7 @@ export function getUserNames(
 export async function createNewUser(
   appUserPostRequest: AppUserPostRequest
 ): Promise<AppUserResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const userApi = new UserApi(apiConfig);
   const request: UserControllerCreateUserRequest = {
     appUserPostRequest,
@@ -86,7 +86,7 @@ export async function updateUserProfile(
   userID: number,
   appUserPostRequest: AppUserPostRequest
 ) {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const userApi = new UserApi(apiConfig);
   const request: UserControllerUpdateUserProfileRequest = {
     userID,
@@ -99,7 +99,7 @@ export async function updateUserProfile(
 export async function getUserRole(
   userID: number
 ): Promise<AppUserRolesResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const userApi = new UserApi(apiConfig);
   const request: UserControllerGetUserRoleRequest = {
     userID,
@@ -111,7 +111,7 @@ export async function getUserRole(
 export async function getInductionPoints(
   userID: number
 ): Promise<AppUserInducteePointsResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const userApi = new UserApi(apiConfig);
 
   const request: UserControllerGetUserInducteePointsRequest = {
@@ -125,7 +125,7 @@ export async function updateUserInterviewAvailabilities(
   userID: number,
   interviewAvailability: InterviewAvailability[]
 ): Promise<AppUserResponse> {
-  const apiConfig: Configuration = ApiConfigStore.getApiConfig();
+  const apiConfig: Configuration = await ApiConfigStore.getApiConfig();
   const userApi = new UserApi(apiConfig);
 
   const availabilitiesRequest: AppUserInterviewAvailabilitiesRequest = {


### PR DESCRIPTION
Hopefully this will solve the issue of empty event sign ins.
Sign ins had empty names - suspected root cause is that tokens weren't
getting refreshed and thus sign ins were having empty names.